### PR TITLE
Update Python before adding elrepo repository to avoid invalid SSL certificate error.

### DIFF
--- a/provision/playbook.yml
+++ b/provision/playbook.yml
@@ -25,6 +25,12 @@
   tasks:
 
   #
+  # update python
+  #
+  - name: ensure Python is up-to-date
+    yum: name=python state=latest
+
+  #
   # add repos
   #
   - name: ensure elrepo repo is present


### PR DESCRIPTION
Error: `Failed to validate the SSL certificate for www.elrepo.org:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine  (the python executable used (/usr/bin/python) is version: 2.7.5 (default, Jun 17 2014, 18:11:42) [GCC 4.8.2 20140120 (Red Hat 4.8.2-16)]) or you can install the `urllib3`, `pyOpenSSL`, `ndg-httpsclient`, and `pyasn1` python modules to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible.`